### PR TITLE
Remote switch

### DIFF
--- a/compose-switch.yaml
+++ b/compose-switch.yaml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  switchserver:
+    build: ./switchserver
+    ports:
+      - "5002:5002"
+    volumes:
+      - ./db:/db
+      - /dev/bus/usb:/dev/bus/usb
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    cap_add:
+      - SYS_ADMIN
+    network_mode: "host"
+    environment:
+      - SCAN_HCI=2
+      - PYTHONUNBUFFERED=1
+    privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./db:/db
       - /dev/bus/usb:/dev/bus/usb
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    restart: unless-stopped
     cap_add:
       - SYS_ADMIN
     network_mode: "host"
@@ -23,6 +24,7 @@ services:
       - ./db:/db
       - /dev/bus/usb:/dev/bus/usb
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    restart: unless-stopped
     cap_add:
       - SYS_ADMIN
     network_mode: "host"
@@ -38,6 +40,7 @@ services:
       - ./db:/db
       - /dev/bus/usb:/dev/bus/usb
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    restart: unless-stopped
     cap_add:
       - SYS_ADMIN
     network_mode: "host"

--- a/switchserver/Dockerfile
+++ b/switchserver/Dockerfile
@@ -2,5 +2,6 @@ FROM parisbutterfield/restswitch:switchserver
 RUN mkdir /db
 ADD . /code
 WORKDIR /code
+RUN pip install -r requirements.txt
 RUN chmod +x run.sh
 CMD ["/code/run.sh"]

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -50,7 +50,7 @@ class FlaskAppWrapper(object):
         print(content)
         switchqueue.put(content);
         print("Adding relayed request to queue")
-    return ('', 200)
+        return ('', 200)
 
     @app.route('/device/<macaddress>', methods=['PUT'])
     def device(macaddress):

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -59,7 +59,7 @@ class FlaskAppWrapper(object):
         if results != None:
             content = request.get_json(force=True)
             results.update({'on' : content['on']})
-            if macaddress in os.environ:
+            if macaddress in environ:
                 print("Relaying request...")
                 host = environ.get(macaddress)
                 r = requests.put("http://" + host + ":5002/device/relay/" + macaddress, data = json.dumps(results))

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -50,8 +50,7 @@ class FlaskAppWrapper(object):
         print(content)
         switchqueue.put(content);
         print("Adding relayed request to queue")
-        return ('', 200)
-    abort(404)
+    return ('', 200)
 
     @app.route('/device/<macaddress>', methods=['PUT'])
     def device(macaddress):

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -45,7 +45,7 @@ class FlaskAppWrapper(object):
         return (rv[0] if rv else None) if one else rv
 
     @app.route('/device/relay/<macaddress>', methods=['PUT'])
-    def device(macaddress):
+    def devicerelay(macaddress):
         content = request.get_json(force=True)
         print(content)
         switchqueue.put(content);

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -1,5 +1,7 @@
 import sqlite3 as lite
 import json
+import requests
+from os import environ
 from flask import Flask, g, request, abort
 from flask_cors import CORS
 from queue import switchqueue
@@ -42,6 +44,14 @@ class FlaskAppWrapper(object):
         cur.close()
         return (rv[0] if rv else None) if one else rv
 
+    @app.route('/device/relay/<macaddress>', methods=['PUT'])
+    def device(macaddress):
+        content = request.get_json(force=True)
+        print(content)
+        switchqueue.put(content);
+        print("Adding relayed request to queue")
+        return ('', 200)
+    abort(404)
 
     @app.route('/device/<macaddress>', methods=['PUT'])
     def device(macaddress):
@@ -50,7 +60,12 @@ class FlaskAppWrapper(object):
         if results != None:
             content = request.get_json(force=True)
             results.update({'on' : content['on']})
-            switchqueue.put(results);
-            print("Request added to queue")
-            return ('', 200)
+            if macaddress in os.environ
+                print("Relaying request...")
+                host = environ.get(macaddress)
+                r = requests.put("http://" + host + ":5002/device/relay/" + macaddress, data = json.dumps(results))
+            else
+                switchqueue.put(results);
+                print("Request added to queue")
+        return ('', 200)
         abort(404)

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -60,7 +60,7 @@ class FlaskAppWrapper(object):
         if results != None:
             content = request.get_json(force=True)
             results.update({'on' : content['on']})
-            if macaddress in os.environ
+            if macaddress in os.environ:
                 print("Relaying request...")
                 host = environ.get(macaddress)
                 r = requests.put("http://" + host + ":5002/device/relay/" + macaddress, data = json.dumps(results))

--- a/switchserver/app.py
+++ b/switchserver/app.py
@@ -64,8 +64,8 @@ class FlaskAppWrapper(object):
                 print("Relaying request...")
                 host = environ.get(macaddress)
                 r = requests.put("http://" + host + ":5002/device/relay/" + macaddress, data = json.dumps(results))
-            else
-                switchqueue.put(results);
+            else:
+                switchqueue.put(results)
                 print("Request added to queue")
         return ('', 200)
         abort(404)

--- a/switchserver/requirements.txt
+++ b/switchserver/requirements.txt
@@ -1,4 +1,1 @@
-flask
-netaddr
-bluepy
-flask-cors
+requests==2.18.4


### PR DESCRIPTION
Initial support for remote switch. This allows users to have two Pi's and requests to switch will be proxied to a "relay switch". Useful if the Swithmate device can't be reached by the initial device.